### PR TITLE
[DEV] DonationActivity 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 .cxx
 local.properties
 google-services.json
+release/
+debug/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId 'com.yong.taximeter'
         minSdk 24
         targetSdk 34
-        versionCode 1
-        versionName '1.0'
+        versionCode 23
+        versionName '2.0_test1'
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,12 +39,13 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.6.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.6.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'com.google.android.material:material:1.9.0'
 
+    implementation 'com.android.billingclient:billing-ktx:6.0.1'
     implementation 'com.google.firebase:firebase-firestore-ktx'
     implementation platform('com.google.firebase:firebase-bom:32.2.0')
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         applicationId 'com.yong.taximeter'
         minSdk 24
         targetSdk 34
-        versionCode 25
+        versionCode 26
         versionName '2.0_test1'
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         applicationId 'com.yong.taximeter'
         minSdk 24
         targetSdk 34
-        versionCode 23
+        versionCode 25
         versionName '2.0_test1'
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="com.android.vending.BILLING" tools:node="remove" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -7,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="com.android.vending.BILLING" tools:node="remove" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/yong/taximeter/fragment/MainDonateFragment.kt
+++ b/app/src/main/java/com/yong/taximeter/fragment/MainDonateFragment.kt
@@ -1,18 +1,143 @@
 package com.yong.taximeter.fragment
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingClient.ProductType
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.PurchasesUpdatedListener
+import com.android.billingclient.api.QueryProductDetailsParams
 import com.yong.taximeter.R
 
 class MainDonateFragment : Fragment() {
+    private lateinit var btnAdremove: TextView
+    private lateinit var btnBigmac: TextView
+    private lateinit var btnCoffee: TextView
+    private lateinit var btnCoke: TextView
+    private lateinit var btnDinner: TextView
+    private lateinit var btnMoney: TextView
+
+    private lateinit var billingClient: BillingClient
+    private lateinit var queryProductDetailsParams: QueryProductDetailsParams
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_main_donate, container, false)
+        val view = inflater.inflate(R.layout.fragment_main_donate, container, false)
+        btnAdremove = view.findViewById(R.id.tv_donate_adremove)
+        btnBigmac = view.findViewById(R.id.tv_donate_bigmac)
+        btnCoffee = view.findViewById(R.id.tv_donate_coffee)
+        btnCoke = view.findViewById(R.id.tv_donate_coke)
+        btnDinner = view.findViewById(R.id.tv_donate_dinner)
+        btnMoney = view.findViewById(R.id.tv_donate_money)
+        btnAdremove.setOnClickListener(btnListener)
+        btnBigmac.setOnClickListener(btnListener)
+        btnCoffee.setOnClickListener(btnListener)
+        btnCoke.setOnClickListener(btnListener)
+        btnDinner.setOnClickListener(btnListener)
+        btnMoney.setOnClickListener(btnListener)
+
+        initBillingClient()
+
+        return view
+    }
+
+    private fun initBillingClient() {
+        billingClient = BillingClient.newBuilder(requireContext())
+            .setListener(purchaseUpdateListener)
+            .enablePendingPurchases()
+            .build()
+
+        billingClient.startConnection(object : BillingClientStateListener {
+            override fun onBillingSetupFinished(billingResult: BillingResult) {
+                if(billingResult.responseCode !=  BillingResponseCode.OK) {
+                    Log.e("BILLING_CLIENT", billingResult.debugMessage)
+                }
+            }
+            override fun onBillingServiceDisconnected() {
+                Log.e("BILLING_CLIENT", "Failed to Connect to Google Play")
+            }
+        })
+    }
+
+    private fun queryProduct(productID: String) {
+        queryProductDetailsParams = QueryProductDetailsParams.newBuilder()
+            .setProductList(
+                listOf(
+                    QueryProductDetailsParams.Product.newBuilder()
+                        .setProductId(productID)
+                        .setProductType(ProductType.INAPP)
+                        .build()
+                )
+            )
+            .build()
+
+        billingClient.queryProductDetailsAsync(queryProductDetailsParams) { billingResult, productDetailsList ->
+            when (billingResult.responseCode) {
+                BillingResponseCode.OK -> purchaseProduct(productDetailsList[0])
+                else -> Log.e("QUERY_PRODUCT", billingResult.debugMessage)
+            }
+        }
+    }
+
+    private fun purchaseProduct(productDetails: ProductDetails) {
+        val productDetailsParamsList = listOf(
+            BillingFlowParams.ProductDetailsParams.newBuilder()
+                .setProductDetails(productDetails)
+                .build()
+        )
+
+        val billingFlowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(productDetailsParamsList)
+            .build()
+
+        billingClient.launchBillingFlow(requireActivity(), billingFlowParams)
+    }
+
+    private val purchaseUpdateListener = PurchasesUpdatedListener { billingResult, purchases ->
+        if(billingResult.responseCode == BillingResponseCode.OK && purchases != null) {
+            Toast.makeText(requireContext(), "Purchased", Toast.LENGTH_SHORT).show()
+        } else if(billingResult.responseCode == BillingResponseCode.USER_CANCELED) {
+            Toast.makeText(requireContext(), "Cancelled", Toast.LENGTH_SHORT).show()
+        } else if(billingResult.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED) {
+            Toast.makeText(requireContext(), "Already Owned", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(requireContext(), "Error : ${billingResult.debugMessage}", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private val btnListener = View.OnClickListener { view ->
+        when(view.id) {
+            R.id.tv_donate_adremove -> {
+                queryProduct("ad_remove")
+            }
+
+            R.id.tv_donate_bigmac -> {
+                queryProduct("donation_10000")
+            }
+
+            R.id.tv_donate_coffee -> {
+                queryProduct("donation_5000")
+            }
+
+            R.id.tv_donate_coke -> {
+                queryProduct("donation_1000")
+            }
+
+            R.id.tv_donate_dinner -> {
+                queryProduct("donation_50000")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/yong/taximeter/fragment/MainDonateFragment.kt
+++ b/app/src/main/java/com/yong/taximeter/fragment/MainDonateFragment.kt
@@ -123,7 +123,8 @@ class MainDonateFragment : Fragment() {
         } else if(billingResult.responseCode == BillingResponseCode.USER_CANCELED) {
             Toast.makeText(requireContext(), "Cancelled", Toast.LENGTH_SHORT).show()
         } else {
-            Toast.makeText(requireContext(), "Error : ${billingResult.debugMessage}", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), "Error ${billingResult.responseCode} : ${billingResult.debugMessage}", Toast.LENGTH_SHORT).show()
+            Log.e("PURCHASE_UPDATE", billingResult.debugMessage)
         }
     }
 

--- a/app/src/main/java/com/yong/taximeter/fragment/MainDonateFragment.kt
+++ b/app/src/main/java/com/yong/taximeter/fragment/MainDonateFragment.kt
@@ -108,10 +108,20 @@ class MainDonateFragment : Fragment() {
     private val purchaseUpdateListener = PurchasesUpdatedListener { billingResult, purchases ->
         if(billingResult.responseCode == BillingResponseCode.OK && purchases != null) {
             Toast.makeText(requireContext(), "Purchased", Toast.LENGTH_SHORT).show()
+
+            if(purchases[0].products[0].equals("ad_remove")) {
+                // TODO : Remove AD
+                Toast.makeText(requireContext(), "Removed AD", Toast.LENGTH_SHORT).show()
+            }
+        } else if(billingResult.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED) {
+            if(purchases != null && purchases[0].products[0].equals("ad_remove")) {
+                // TODO : Remove AD
+                Toast.makeText(requireContext(), "Removed AD", Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(requireContext(), "Already Owned", Toast.LENGTH_SHORT).show()
+            }
         } else if(billingResult.responseCode == BillingResponseCode.USER_CANCELED) {
             Toast.makeText(requireContext(), "Cancelled", Toast.LENGTH_SHORT).show()
-        } else if(billingResult.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED) {
-            Toast.makeText(requireContext(), "Already Owned", Toast.LENGTH_SHORT).show()
         } else {
             Toast.makeText(requireContext(), "Error : ${billingResult.debugMessage}", Toast.LENGTH_SHORT).show()
         }


### PR DESCRIPTION
## Summary
Donation Page의 In-App Purchase를 구현하였습니다.

## Description
- Google Play Billing V6 라이브러리를 기반으로 In-App Purchase를 구성하였습니다.
- Donation Fragment 진입 시, Google Play Billing Client를 init합니다.
- 각 구매 항목 클릭 시, 해당 항목에 대한 SKU 정보를 Query하며, 성공 시 Google Play 결제 컴포넌트를 렌더링합니다.
- 기존에 이미 구매한 광고제거 항목의 경우, 이미 보유한다는 결과가 표시되며, 상세한 로직은 추후 수정이 필요합니다.
- 결제 수행 시, Error Code 3이 반환되는 문제가 있습니다. Google Play 결제 프로필 이슈로 추정되며, Google 문의 후 추후 FIX Issue를 개설하여 작업 예정입니다. 이후의 디버깅을 위해 일부 Log 코드를 제거하지 않았습니다.

![image](https://github.com/yymin1022/TaxiMeter/assets/12806229/efdba62b-ec3c-4f38-a7a8-0d8b5eceac3b)
