### PR TITLE
[FIX] MeterActivity Wakelock 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         applicationId 'com.yong.taximeter'
         minSdk 24
         targetSdk 34
-        versionCode 30
+        versionCode 31
         versionName '2.0_release1'
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/java/com/yong/taximeter/activity/MeterActivity.kt
+++ b/app/src/main/java/com/yong/taximeter/activity/MeterActivity.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.AnimationDrawable
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
@@ -128,6 +129,7 @@ class MeterActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         LocalBroadcastManager.getInstance(this).registerReceiver(statusReceiver, IntentFilter("METER_STATUS"))
         LocalBroadcastManager.getInstance(this).registerReceiver(updateReceiver, IntentFilter("UPDATE_METER"))


### PR DESCRIPTION
## Summary
MeterActivity에 WakeLock을 적용하였습니다.

## Description
- MeterActivity의 `onResume` 생명주기에 `FLAG_KEEP_SCREEN_ON` 플래그를 추가하였습니다.
- `versionCode`를 31로 조정하였습니다.